### PR TITLE
Replace direct arktype imports with @lobomfz/db in indexers

### DIFF
--- a/src/integrations/indexers/beyond-hd.ts
+++ b/src/integrations/indexers/beyond-hd.ts
@@ -1,4 +1,4 @@
-import { type } from 'arktype'
+import { type } from '@lobomfz/db'
 import axios from 'redaxios'
 
 import type { media_type } from '@/db/connection'

--- a/src/integrations/indexers/subdl.ts
+++ b/src/integrations/indexers/subdl.ts
@@ -1,4 +1,4 @@
-import { type } from 'arktype'
+import { type } from '@lobomfz/db'
 import axios from 'redaxios'
 
 import { envVariables } from '@/lib/env'

--- a/src/integrations/indexers/superflix.ts
+++ b/src/integrations/indexers/superflix.ts
@@ -1,4 +1,4 @@
-import { type } from 'arktype'
+import { type } from '@lobomfz/db'
 import axios from 'redaxios'
 
 import { envVariables } from '@/lib/env'

--- a/src/integrations/indexers/types.ts
+++ b/src/integrations/indexers/types.ts
@@ -1,5 +1,4 @@
-import type { DbFieldMeta } from '@lobomfz/db'
-import type { Type } from 'arktype'
+import type { DbFieldMeta, Type } from '@lobomfz/db'
 
 import type { download_source, media_type } from '@/db/connection'
 

--- a/src/integrations/indexers/yts.ts
+++ b/src/integrations/indexers/yts.ts
@@ -1,4 +1,4 @@
-import { type } from 'arktype'
+import { type } from '@lobomfz/db'
 import axios from 'redaxios'
 
 import { envVariables } from '@/lib/env'


### PR DESCRIPTION
## Summary
- Replaced `import { type } from 'arktype'` with `import { type } from '@lobomfz/db'` in beyond-hd.ts, subdl.ts, yts.ts, superflix.ts
- Merged `Type` type import from arktype into the existing `@lobomfz/db` import in types.ts
- No logic changes, only import paths

## Test plan
- [x] `tsgo` passes with 0 errors
- [x] All 537 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)