### PR TITLE
Replace direct arktype imports with @lobomfz/db in src/lib/

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,7 +1,7 @@
-import { type } from 'arktype'
+import { type } from '@lobomfz/db'
 
-import { envVariables } from '@/lib/env'
 import { indexerSchema } from '@/integrations/indexers/registry'
+import { envVariables } from '@/lib/env'
 import { Log } from '@/lib/log'
 
 const qbittorrentClient = type({

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,7 +1,7 @@
 import { homedir } from 'os'
 import { join } from 'path'
 
-import { type } from 'arktype'
+import { type } from '@lobomfz/db'
 
 const xdgConfigHome = process.env.XDG_CONFIG_HOME ?? join(homedir(), '.config')
 const xdgDataHome = process.env.XDG_DATA_HOME ?? join(homedir(), '.local/share')

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,4 +1,4 @@
-import { type Type } from 'arktype'
+import { type Type } from '@lobomfz/db'
 
 // TODO: maybe find a better way to do this
 export function extractSchemaProps(schema: Type) {


### PR DESCRIPTION
## Summary
- Replaced `import { type } from 'arktype'` with `import { type } from '@lobomfz/db'` in `src/lib/env.ts` and `src/lib/config.ts`
- Replaced `import { type Type } from 'arktype'` with `import { type Type } from '@lobomfz/db'` in `src/lib/utils.ts`
- `src/api/schemas.ts` does not exist on this branch (already deleted), so no change needed there

## Test plan
- [x] `bun check` passes (type-check + lint clean; pre-existing test failures unrelated to this change)
- [x] Verified failures exist before and after the change (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)