### PR TITLE
Replace direct arktype imports with @lobomfz/db in test mocks

### DIFF
--- a/tests/mocks/beyond-hd.ts
+++ b/tests/mocks/beyond-hd.ts
@@ -1,5 +1,5 @@
+import { type } from '@lobomfz/db'
 import { Mock } from '@lobomfz/ghostapi'
-import { type } from 'arktype'
 
 import { envVariables } from '@/lib/env'
 

--- a/tests/mocks/qbittorrent.ts
+++ b/tests/mocks/qbittorrent.ts
@@ -1,5 +1,5 @@
+import { type } from '@lobomfz/db'
 import { Mock } from '@lobomfz/ghostapi'
-import { type } from 'arktype'
 
 export const QBittorrentMock = new Mock(
   {

--- a/tests/mocks/subdl.ts
+++ b/tests/mocks/subdl.ts
@@ -1,5 +1,5 @@
+import { type } from '@lobomfz/db'
 import { Mock } from '@lobomfz/ghostapi'
-import { type } from 'arktype'
 import { strToU8, zipSync } from 'fflate'
 
 import { envVariables } from '@/lib/env'

--- a/tests/mocks/superflix.ts
+++ b/tests/mocks/superflix.ts
@@ -1,9 +1,9 @@
 import { tmpdir } from 'os'
 import { join } from 'path'
 
+import { type } from '@lobomfz/db'
 import { FFmpegBuilder } from '@lobomfz/ffmpeg'
 import { Mock } from '@lobomfz/ghostapi'
-import { type } from 'arktype'
 
 import { envVariables } from '@/lib/env'
 

--- a/tests/mocks/tmdb.ts
+++ b/tests/mocks/tmdb.ts
@@ -1,5 +1,5 @@
+import { type } from '@lobomfz/db'
 import { Mock } from '@lobomfz/ghostapi'
-import { type } from 'arktype'
 
 import { envVariables } from '@/lib/env'
 

--- a/tests/mocks/yts.ts
+++ b/tests/mocks/yts.ts
@@ -1,5 +1,5 @@
+import { type } from '@lobomfz/db'
 import { Mock } from '@lobomfz/ghostapi'
-import { type } from 'arktype'
 
 import { envVariables } from '@/lib/env'
 


### PR DESCRIPTION
## Summary
- Replace `import { type } from 'arktype'` with `import { type } from '@lobomfz/db'` in all 6 files under `tests/mocks/`
- Files changed: beyond-hd.ts, yts.ts, tmdb.ts, qbittorrent.ts, superflix.ts, subdl.ts
- No logic changes -- purely import path consolidation

## Test plan
- [x] `bun check` passes type-check and lint (27 pre-existing test failures unrelated to this change; base branch has 31)
- [x] Verified diff is strictly limited to import lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)