### PR TITLE
Replace direct arktype imports with @lobomfz/db in commands

### DIFF
--- a/src/commands/download.ts
+++ b/src/commands/download.ts
@@ -1,5 +1,5 @@
 import { defineCommand, option } from '@bunli/core'
-import { type } from 'arktype'
+import { type } from '@lobomfz/db'
 
 import { Handler } from '@/commands/handler'
 

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -1,5 +1,5 @@
 import { defineCommand, option } from '@bunli/core'
-import { type } from 'arktype'
+import { type } from '@lobomfz/db'
 
 import { Handler } from '@/commands/handler'
 

--- a/src/commands/handler.ts
+++ b/src/commands/handler.ts
@@ -1,6 +1,6 @@
 import { resolve } from 'path'
 
-import { type, type Type } from 'arktype'
+import { type, type Type } from '@lobomfz/db'
 
 import { MIN_SYNC_CONFIDENCE } from '@/audio/audio-correlator'
 import { Downloads } from '@/core/downloads'

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -1,5 +1,5 @@
 import { defineCommand, option } from '@bunli/core'
-import { type } from 'arktype'
+import { type } from '@lobomfz/db'
 
 import { Handler } from '@/commands/handler'
 

--- a/src/commands/init-wizard.ts
+++ b/src/commands/init-wizard.ts
@@ -2,12 +2,12 @@ import { mkdir } from 'fs/promises'
 import { dirname, join } from 'path'
 
 import type { PromptApi } from '@bunli/core'
-import type { Type } from 'arktype'
+import type { Type } from '@lobomfz/db'
 
+import { indexerMap } from '@/integrations/indexers/registry'
 import type { Config, ConfigInput } from '@/lib/config'
 import { configJsonSchema } from '@/lib/config'
 import { envVariables } from '@/lib/env'
-import { indexerMap } from '@/integrations/indexers/registry'
 import { Log } from '@/lib/log'
 
 interface SchemaProp {

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,5 +1,5 @@
 import { defineCommand, option } from '@bunli/core'
-import { type } from 'arktype'
+import { type } from '@lobomfz/db'
 
 import { InitWizard } from '@/commands/init-wizard'
 

--- a/src/commands/library.ts
+++ b/src/commands/library.ts
@@ -1,5 +1,5 @@
 import { defineCommand, option } from '@bunli/core'
-import { type } from 'arktype'
+import { type } from '@lobomfz/db'
 
 import { Handler } from '@/commands/handler'
 

--- a/src/commands/play.ts
+++ b/src/commands/play.ts
@@ -1,5 +1,5 @@
 import { defineCommand, option } from '@bunli/core'
-import { type } from 'arktype'
+import { type } from '@lobomfz/db'
 
 import { Handler } from '@/commands/handler'
 

--- a/src/commands/releases.ts
+++ b/src/commands/releases.ts
@@ -1,5 +1,5 @@
 import { defineCommand, option } from '@bunli/core'
-import { type } from 'arktype'
+import { type } from '@lobomfz/db'
 
 import { Handler } from '@/commands/handler'
 

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -1,5 +1,5 @@
 import { defineCommand, option } from '@bunli/core'
-import { type } from 'arktype'
+import { type } from '@lobomfz/db'
 
 import { Handler } from '@/commands/handler'
 

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -1,5 +1,5 @@
 import { defineCommand, option } from '@bunli/core'
-import { type } from 'arktype'
+import { type } from '@lobomfz/db'
 
 import { Handler } from '@/commands/handler'
 

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -1,5 +1,5 @@
 import { defineCommand, option } from '@bunli/core'
-import { type } from 'arktype'
+import { type } from '@lobomfz/db'
 
 import { Handler } from '@/commands/handler'
 

--- a/src/commands/subtitles.ts
+++ b/src/commands/subtitles.ts
@@ -1,5 +1,5 @@
 import { defineCommand, option } from '@bunli/core'
-import { type } from 'arktype'
+import { type } from '@lobomfz/db'
 
 import { Handler } from '@/commands/handler'
 import { subdlLanguage } from '@/integrations/indexers/subdl'


### PR DESCRIPTION
## Summary
- Replaced `import { type } from 'arktype'` with `import { type } from '@lobomfz/db'` across 13 files in `src/commands/`
- `handler.ts` also re-routed `type Type` import; `init-wizard.ts` re-routed `type Type` type-only import
- No runtime behavior change; all 537 tests pass

## Test plan
- [x] `bun test` -- 537 pass, 0 fail
- [x] `bun check` -- tsgo 0 errors, oxlint clean (pre-existing unrelated failures unchanged)
- [x] Verified no `arktype` imports remain in the 13 target files

🤖 Generated with [Claude Code](https://claude.com/claude-code)