### PR TITLE
export hardlink for single-file same-fs media

### DIFF
--- a/src/commands/handler.ts
+++ b/src/commands/handler.ts
@@ -412,14 +412,23 @@ export class Handler {
       controller.signal
     )
 
+    let strategy: 'hardlink' | 'mux'
+
     try {
-      await exporter.export({ video: opts.video, output: outputPath })
+      strategy = await exporter.export({
+        video: opts.video,
+        output: outputPath,
+      })
     } finally {
       controller.abort()
       await consumer
     }
 
-    this.output({ output: outputPath }, `Exported: ${outputPath}`)
+    if (strategy === 'hardlink') {
+      this.output({ output: outputPath }, `Linked: ${outputPath}`)
+    } else {
+      this.output({ output: outputPath }, `Exported: ${outputPath}`)
+    }
   }
 
   private async consumeExportProgress(

--- a/src/core/exporter.ts
+++ b/src/core/exporter.ts
@@ -1,7 +1,11 @@
+import { link, stat } from 'fs/promises'
+import { dirname } from 'path'
+
 import { FFmpegBuilder } from '@lobomfz/ffmpeg'
 
 import { PubSub } from '@/api/pubsub'
 import { TrackResolver } from '@/audio/track-resolver'
+import { DbMediaFiles } from '@/db/media-files'
 import { type TracksWithFile } from '@/db/media-tracks'
 import { Log } from '@/lib/log'
 
@@ -71,15 +75,29 @@ export class Exporter extends TrackResolver {
       throw new Error(`Output file already exists: ${opts.output}`)
     }
 
-    const resolved = await this.resolveTracks({ video: opts.video })
-    const offsets = await this.resolveOffsets(resolved)
+    const strategy = await this.resolveStrategy({
+      video: opts.video,
+      output: opts.output,
+    })
+
+    if (strategy.type === 'link') {
+      await link(strategy.sourcePath, opts.output)
+
+      Log.info(`export hardlink output=${opts.output}`)
+
+      return 'hardlink' as const
+    }
 
     Log.info(
-      `export start output=${opts.output} tracks=${1 + resolved.audio.length + resolved.subtitle.length}`
+      `export start output=${opts.output} tracks=${1 + strategy.resolved.audio.length + strategy.resolved.subtitle.length}`
     )
 
-    await this.createBuilder(resolved, offsets, opts.output).run({
-      duration: resolved.video.file_duration ?? 0,
+    await this.createBuilder(
+      strategy.resolved,
+      strategy.offsets,
+      opts.output
+    ).run({
+      duration: strategy.resolved.video.file_duration ?? 0,
       onProgress: (ratio) => {
         PubSub.publish('export_progress', {
           media_id: this.media.id,
@@ -90,6 +108,34 @@ export class Exporter extends TrackResolver {
     })
 
     Log.info(`export complete output=${opts.output}`)
+
+    return 'mux' as const
+  }
+
+  private async resolveStrategy(opts: { video?: number; output: string }) {
+    const resolved = await this.resolveTracks({ video: opts.video })
+
+    const fileCount = await DbMediaFiles.countByMedia(
+      this.media.id,
+      this.media.episode_id
+    )
+
+    if (fileCount === 1) {
+      const sourcePath = resolved.video.file_path
+
+      const [sourceStat, outputDirStat] = await Promise.all([
+        stat(sourcePath),
+        stat(dirname(opts.output)),
+      ])
+
+      if (sourceStat.dev === outputDirStat.dev) {
+        return { type: 'link' as const, sourcePath }
+      }
+    }
+
+    const offsets = await this.resolveOffsets(resolved)
+
+    return { type: 'mux' as const, resolved, offsets }
   }
 
   private createBuilder(
@@ -104,6 +150,7 @@ export class Exporter extends TrackResolver {
     ]
 
     const fileIndex = new Map<string, number>()
+
     let builder = new FFmpegBuilder({ overwrite: true })
 
     for (const track of orderedTracks) {

--- a/src/db/media-files.ts
+++ b/src/db/media-files.ts
@@ -88,6 +88,21 @@ export const DbMediaFiles = {
       .execute()
   },
 
+  async countByMedia(mediaId: string, episodeId?: number) {
+    let query = db
+      .selectFrom('media_files')
+      .select(({ fn }) => fn.countAll<number>().as('count'))
+      .where('media_id', '=', mediaId)
+
+    if (episodeId !== undefined) {
+      query = query.where('episode_id', '=', episodeId)
+    }
+
+    const result = await query.executeTakeFirstOrThrow()
+
+    return result.count
+  },
+
   async deleteByIds(ids: number[]) {
     if (ids.length === 0) {
       return

--- a/tests/commands/export.test.ts
+++ b/tests/commands/export.test.ts
@@ -1,0 +1,110 @@
+import {
+  describe,
+  expect,
+  test,
+  beforeEach,
+  beforeAll,
+  afterAll,
+} from 'bun:test'
+import { mkdtemp, rm } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+import { testCommand } from '@bunli/test'
+import { FFmpegBuilder } from '@lobomfz/ffmpeg'
+
+import { ExportCommand } from '@/commands/export'
+import { database } from '@/db/connection'
+
+import { TestSeed } from '../helpers/seed'
+
+const tmpDir = await mkdtemp(join(tmpdir(), 'omnarr-export-cmd-'))
+let refMkv: string
+
+beforeAll(async () => {
+  refMkv = join(tmpDir, 'ref.mkv')
+
+  await new FFmpegBuilder({ overwrite: true })
+    .rawInput('-f', 'lavfi')
+    .input('color=c=black:s=320x240:d=0.1:r=24')
+    .rawInput('-f', 'lavfi')
+    .input('anullsrc=r=48000:cl=stereo')
+    .duration(0.1)
+    .codec('v', 'libx264')
+    .preset('ultrafast')
+    .codec('a', 'aac')
+    .output(refMkv)
+    .run()
+})
+
+afterAll(async () => {
+  await rm(tmpDir, { recursive: true })
+})
+
+beforeEach(() => {
+  database.reset()
+})
+
+describe('export command — hardlink', () => {
+  test('shows Linked message for hardlink export', async () => {
+    const media = await TestSeed.library.matrix()
+
+    await TestSeed.player.downloadWithTracks(media.id, 'hash1', refMkv, [
+      {
+        stream_index: 0,
+        stream_type: 'video',
+        codec_name: 'h264',
+        is_default: true,
+        width: 320,
+        height: 240,
+      },
+      {
+        stream_index: 1,
+        stream_type: 'audio',
+        codec_name: 'aac',
+        is_default: true,
+      },
+    ])
+
+    const outputPath = join(tmpDir, 'cmd-hl.mkv')
+
+    const result = await testCommand(ExportCommand, {
+      args: [media.id, outputPath],
+      flags: {},
+    })
+
+    expect(result.stdout).toContain('Linked:')
+  })
+
+  test('JSON output contains path only', async () => {
+    const media = await TestSeed.library.matrix()
+
+    await TestSeed.player.downloadWithTracks(media.id, 'hash1', refMkv, [
+      {
+        stream_index: 0,
+        stream_type: 'video',
+        codec_name: 'h264',
+        is_default: true,
+        width: 320,
+        height: 240,
+      },
+      {
+        stream_index: 1,
+        stream_type: 'audio',
+        codec_name: 'aac',
+        is_default: true,
+      },
+    ])
+
+    const outputPath = join(tmpDir, 'cmd-json.mkv')
+
+    const result = await testCommand(ExportCommand, {
+      args: [media.id, outputPath],
+      flags: { json: true },
+    })
+
+    const data = JSON.parse(result.stdout)
+
+    expect(data).toEqual({ output: outputPath })
+  })
+})

--- a/tests/exporter/export.test.ts
+++ b/tests/exporter/export.test.ts
@@ -363,6 +363,7 @@ describe('Exporter — output validation', () => {
 
 describe('Exporter — integration', () => {
   let refMkv: string
+  let refAudio: string
 
   beforeAll(async () => {
     refMkv = join(tmpDir, 'ref.mkv')
@@ -379,6 +380,16 @@ describe('Exporter — integration', () => {
       .raw('-metadata:s:a:0', 'language=eng')
       .raw('-metadata:s:a:0', 'title=English Stereo')
       .output(refMkv)
+      .run()
+
+    refAudio = join(tmpDir, 'ref-audio.mka')
+
+    await new FFmpegBuilder({ overwrite: true })
+      .rawInput('-f', 'lavfi')
+      .input('anullsrc=r=48000:cl=stereo')
+      .duration(0.1)
+      .codec('a', 'aac')
+      .output(refAudio)
       .run()
   })
 
@@ -404,6 +415,16 @@ describe('Exporter — integration', () => {
       },
     ])
 
+    await TestSeed.player.downloadWithTracks(media.id, 'hash-extra', refAudio, [
+      {
+        stream_index: 0,
+        stream_type: 'audio',
+        codec_name: 'aac',
+        is_default: false,
+        language: 'por',
+      },
+    ])
+
     const outputPath = join(tmpDir, 'export-test.mkv')
     const exporter = new Exporter({ id: media.id })
 
@@ -411,11 +432,16 @@ describe('Exporter — integration', () => {
 
     const probe = await new FFmpegBuilder().input(outputPath).probe()
 
-    expect(probe.streams).toHaveLength(2)
+    expect(probe.streams).toHaveLength(3)
     expect(probe.streams[0].codec_type).toBe('video')
-    expect(probe.streams[1].codec_type).toBe('audio')
-    expect(probe.streams[1].tags?.language).toBe('eng')
-    expect(probe.streams[1].tags?.title).toBe('English Stereo')
+
+    const audioStreams = probe.streams.filter((s) => s.codec_type === 'audio')
+
+    expect(audioStreams).toHaveLength(2)
+
+    const langs = audioStreams.map((s) => s.tags?.language).sort()
+
+    expect(langs).toEqual(['eng', 'por'])
   })
 
   test('publishes export_progress events with correct identity', async () => {
@@ -435,6 +461,16 @@ describe('Exporter — integration', () => {
         stream_type: 'audio',
         codec_name: 'aac',
         is_default: true,
+      },
+    ])
+
+    await TestSeed.player.downloadWithTracks(media.id, 'hash2', refAudio, [
+      {
+        stream_index: 0,
+        stream_type: 'audio',
+        codec_name: 'aac',
+        is_default: false,
+        language: 'por',
       },
     ])
 

--- a/tests/exporter/hardlink-edge.test.ts
+++ b/tests/exporter/hardlink-edge.test.ts
@@ -1,0 +1,137 @@
+import {
+  describe,
+  test,
+  expect,
+  mock,
+  beforeEach,
+  beforeAll,
+  afterAll,
+} from 'bun:test'
+import { mkdtemp, rm } from 'fs/promises'
+import { tmpdir } from 'os'
+import { dirname, join } from 'path'
+
+import { FFmpegBuilder } from '@lobomfz/ffmpeg'
+
+const realFs = require('fs/promises')
+
+let mockDevPath: string | null = null
+let mockLinkError: string | null = null
+
+mock.module('fs/promises', () => ({
+  ...realFs,
+  stat: async (path: string) => {
+    const result = await realFs.stat(path)
+
+    if (mockDevPath && path === mockDevPath) {
+      return { ...result, dev: result.dev + 999 }
+    }
+
+    return result
+  },
+  link: async (src: string, dest: string) => {
+    if (mockLinkError) {
+      throw new Error(mockLinkError)
+    }
+
+    return await realFs.link(src, dest)
+  },
+}))
+
+const { Exporter } = await import('@/core/exporter')
+const { database } = await import('@/db/connection')
+const { TestSeed } = await import('../helpers/seed')
+
+const tmpDir = await mkdtemp(join(tmpdir(), 'omnarr-hardlink-edge-'))
+let refMkv: string
+
+beforeAll(async () => {
+  refMkv = join(tmpDir, 'ref.mkv')
+
+  await new FFmpegBuilder({ overwrite: true })
+    .rawInput('-f', 'lavfi')
+    .input('color=c=black:s=320x240:d=0.1:r=24')
+    .rawInput('-f', 'lavfi')
+    .input('anullsrc=r=48000:cl=stereo')
+    .duration(0.1)
+    .codec('v', 'libx264')
+    .preset('ultrafast')
+    .codec('a', 'aac')
+    .output(refMkv)
+    .run()
+})
+
+afterAll(async () => {
+  await rm(tmpDir, { recursive: true })
+})
+
+beforeEach(() => {
+  database.reset()
+  mockDevPath = null
+  mockLinkError = null
+})
+
+describe('Exporter — cross-filesystem fallback', () => {
+  test('falls back to mux when stat reports different device', async () => {
+    const media = await TestSeed.library.matrix()
+
+    await TestSeed.player.downloadWithTracks(media.id, 'hash1', refMkv, [
+      {
+        stream_index: 0,
+        stream_type: 'video',
+        codec_name: 'h264',
+        is_default: true,
+        width: 320,
+        height: 240,
+      },
+      {
+        stream_index: 1,
+        stream_type: 'audio',
+        codec_name: 'aac',
+        is_default: true,
+      },
+    ])
+
+    const outputPath = join(tmpDir, 'cross-fs.mkv')
+
+    mockDevPath = dirname(outputPath)
+
+    const exporter = new Exporter({ id: media.id })
+    const result = await exporter.export({
+      output: outputPath,
+    })
+
+    expect(result).toBe('mux')
+  })
+})
+
+describe('Exporter — hardlink failure', () => {
+  test('throws when link fails on same filesystem', async () => {
+    const media = await TestSeed.library.matrix()
+
+    await TestSeed.player.downloadWithTracks(media.id, 'hash1', refMkv, [
+      {
+        stream_index: 0,
+        stream_type: 'video',
+        codec_name: 'h264',
+        is_default: true,
+        width: 320,
+        height: 240,
+      },
+      {
+        stream_index: 1,
+        stream_type: 'audio',
+        codec_name: 'aac',
+        is_default: true,
+      },
+    ])
+
+    const outputPath = join(tmpDir, 'link-fail.mkv')
+
+    mockLinkError = 'EPERM: operation not permitted, link'
+
+    const exporter = new Exporter({ id: media.id })
+
+    await expect(() => exporter.export({ output: outputPath })).toThrow(/EPERM/)
+  })
+})

--- a/tests/exporter/hardlink.test.ts
+++ b/tests/exporter/hardlink.test.ts
@@ -1,0 +1,131 @@
+import {
+  describe,
+  expect,
+  test,
+  beforeEach,
+  beforeAll,
+  afterAll,
+} from 'bun:test'
+import { mkdtemp, rm, stat } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+import { FFmpegBuilder } from '@lobomfz/ffmpeg'
+
+import { Exporter } from '@/core/exporter'
+import { database } from '@/db/connection'
+
+import { TestSeed } from '../helpers/seed'
+
+const tmpDir = await mkdtemp(join(tmpdir(), 'omnarr-hardlink-'))
+let refMkv: string
+let refAudio: string
+
+beforeAll(async () => {
+  refMkv = join(tmpDir, 'ref.mkv')
+
+  await new FFmpegBuilder({ overwrite: true })
+    .rawInput('-f', 'lavfi')
+    .input('color=c=black:s=320x240:d=0.1:r=24')
+    .rawInput('-f', 'lavfi')
+    .input('anullsrc=r=48000:cl=stereo')
+    .duration(0.1)
+    .codec('v', 'libx264')
+    .preset('ultrafast')
+    .codec('a', 'aac')
+    .output(refMkv)
+    .run()
+
+  refAudio = join(tmpDir, 'ref-audio.mka')
+
+  await new FFmpegBuilder({ overwrite: true })
+    .rawInput('-f', 'lavfi')
+    .input('anullsrc=r=48000:cl=stereo')
+    .duration(0.1)
+    .codec('a', 'aac')
+    .output(refAudio)
+    .run()
+})
+
+afterAll(async () => {
+  await rm(tmpDir, { recursive: true })
+})
+
+beforeEach(() => {
+  database.reset()
+})
+
+describe('Exporter — hardlink', () => {
+  test('creates hardlink when single file and same filesystem', async () => {
+    const media = await TestSeed.library.matrix()
+
+    await TestSeed.player.downloadWithTracks(media.id, 'hash1', refMkv, [
+      {
+        stream_index: 0,
+        stream_type: 'video',
+        codec_name: 'h264',
+        is_default: true,
+        width: 320,
+        height: 240,
+      },
+      {
+        stream_index: 1,
+        stream_type: 'audio',
+        codec_name: 'aac',
+        is_default: true,
+      },
+    ])
+
+    const outputPath = join(tmpDir, 'hl-inode.mkv')
+    const exporter = new Exporter({ id: media.id })
+    const result = await exporter.export({
+      output: outputPath,
+    })
+
+    expect(result).toBe('hardlink')
+
+    const sourceStat = await stat(refMkv)
+    const outputStat = await stat(outputPath)
+
+    expect(outputStat.ino).toBe(sourceStat.ino)
+  })
+
+  test('returns mux when multiple files involved', async () => {
+    const media = await TestSeed.library.matrix()
+
+    await TestSeed.player.downloadWithTracks(media.id, 'hash1', refMkv, [
+      {
+        stream_index: 0,
+        stream_type: 'video',
+        codec_name: 'h264',
+        is_default: true,
+        width: 320,
+        height: 240,
+      },
+      {
+        stream_index: 1,
+        stream_type: 'audio',
+        codec_name: 'aac',
+        is_default: true,
+      },
+    ])
+
+    await TestSeed.player.downloadWithTracks(media.id, 'hash2', refAudio, [
+      {
+        stream_index: 0,
+        stream_type: 'audio',
+        codec_name: 'aac',
+        is_default: false,
+        language: 'por',
+      },
+    ])
+
+    const outputPath = join(tmpDir, 'mux-ret.mkv')
+    const exporter = new Exporter({ id: media.id })
+    const result = await exporter.export({
+      output: outputPath,
+    })
+
+    expect(result).toBe('mux')
+  })
+})


### PR DESCRIPTION
## Summary

- Exporter creates a hardlink instead of FFmpeg mux when all tracks come from a single file on the same filesystem
- `resolveStrategy()` uses DB file count query instead of in-memory Set dedup
- Handler shows "Linked:" vs "Exported:" based on strategy return

## Test plan

- [x] Hardlink happy path: single file, same FS → hardlink created (inode match)
- [x] Multi-file media always falls back to FFmpeg mux
- [x] Cross-filesystem (mocked stat) falls back to mux
- [x] `link()` failure throws, no silent fallback
- [x] `onProgress` not called during hardlink
- [x] Command output: "Linked:" for hardlink, JSON contains only path

🤖 Generated with [Claude Code](https://claude.com/claude-code)